### PR TITLE
Lift project to Kafka clients 3.6, Spring Kafka 3.1 and Spring Boot 3.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target/
 /.idea/
 *.iml
 sequence-producer.state
+dependency-reduced-pom.xml
+

--- a/README.md
+++ b/README.md
@@ -168,6 +168,14 @@ deserialization errors for consumers expecting JSON payload.
 The commands 'newtopic', 'deltopic' and 'showtopics' allow simple administration
 of Kafka topics for testing purposes.
 
+### Tip regarding terminal usage
+
+The examples generally require multiple terminal windows, in order to start
+different producer/consumer processes in parallel with visible output. Using
+only terminal tabs is perhaps not the best option, because you will not be able
+to see in real time the different outputs together. If you are already using
+something like tmux you can benefit greatly by using multiple panes and windows.
+
 ### Running directly from IntelliJ
 
 You can create run configurations in IntelliJ for all the examples, by starting

--- a/README.md
+++ b/README.md
@@ -105,14 +105,14 @@ docker-compose works on your host:
 
     mvn install
     
-If all goes well, an executable über-jar is built in
-`clients/target/clients-<version>-exec.jar` for the basic Java clients. The
-automated tests actually spin up Kafka on localhost, and so take a while to
-complete. To skip the tests during development iterations, use `mvn install
--DskipTests` instead.
+If all goes well, an executable jar is built in
+`clients/target/clients-<version>.jar` for the basic Java clients. The automated
+tests actually spin up Kafka on localhost, and so take a while to complete. To
+skip the tests during development iterations, use `mvn install -DskipTests`
+instead.
 
 The jar-file can be executed simply by running `./run` from the project
-top directory, or alternatively using `java -jar clients/target/clients-*-exec.jar`.
+top directory, or alternatively using `java -jar clients/target/clients-*.jar`.
 
 ### Running a Kafka environment on localhost             <a name="local-kafka"/>
 

--- a/boot-app
+++ b/boot-app
@@ -4,10 +4,10 @@ set -e
 cd "$(dirname "$0")"
 
 if ! test -f messages/target/messages-*.jar -a\
-     -f clients-spring/target/clients-spring-*-exec.jar; then
+     -f clients-spring/target/clients-spring-*.jar; then
     mvn -B install
 fi
 
 cd clients-spring
-exec java -jar target/clients-spring-*-exec.jar "$@"
+exec java -jar target/clients-spring-*.jar "$@"
 

--- a/clients-spring/pom.xml
+++ b/clients-spring/pom.xml
@@ -15,7 +15,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <spring-boot.version>2.6.1</spring-boot.version>
+        <spring-boot.version>2.6.6</spring-boot.version>
     </properties>
 
     <dependencyManagement>

--- a/clients-spring/pom.xml
+++ b/clients-spring/pom.xml
@@ -8,27 +8,9 @@
         <groupId>no.nav.kafka</groupId>
         <artifactId>kafka-sandbox</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>clients-spring</artifactId>
-    <packaging>jar</packaging>
-
-    <properties>
-        <spring-boot.version>2.6.6</spring-boot.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-parent</artifactId>
-                <version>${spring-boot.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -56,38 +38,20 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.junit.vintage</groupId>
-                    <artifactId>junit-vintage-engine</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring-boot.version}</version>
                 <executions>
                     <execution>
                         <id>repackage</id>
                         <goals>
                             <goal>repackage</goal>
                         </goals>
-                        <configuration>
-                            <classifier>exec</classifier>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/clients-spring/src/main/java/no/nav/kafka/sandbox/data/EventStoreWithFailureRate.java
+++ b/clients-spring/src/main/java/no/nav/kafka/sandbox/data/EventStoreWithFailureRate.java
@@ -94,7 +94,7 @@ public class EventStoreWithFailureRate<T> extends DefaultEventStore<T> {
 
         public AverageRatioRandom(float failureRate) {
             if (failureRate < 0 || failureRate > 1.0) {
-                throw new IllegalArgumentException("failure rate must be a decmial number between 0.0 and 1.0");
+                throw new IllegalArgumentException("failure rate must be a decimal number between 0.0 and 1.0");
             }
             this.failureRate = failureRate;
         }

--- a/clients-spring/src/main/java/no/nav/kafka/sandbox/measurements/MeasurementsConsumer.java
+++ b/clients-spring/src/main/java/no/nav/kafka/sandbox/measurements/MeasurementsConsumer.java
@@ -1,7 +1,6 @@
 package no.nav.kafka.sandbox.measurements;
 
 import no.nav.kafka.sandbox.data.EventStore;
-import no.nav.kafka.sandbox.measurements.errorhandlers.RecoveringErrorHandler;
 import no.nav.kafka.sandbox.messages.Measurements;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
@@ -9,10 +8,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.listener.BatchErrorHandler;
 import org.springframework.kafka.listener.BatchListenerFailedException;
 import org.springframework.kafka.support.serializer.DeserializationException;
-import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.SerializationUtils;
 import org.springframework.stereotype.Component;
 
 import java.io.ByteArrayInputStream;
@@ -40,14 +38,14 @@ public class MeasurementsConsumer {
 
     private final long slowdownMillis;
 
-    private final boolean usingRecoveringBatchErrorHandler;
+    private final boolean useBatchListenerFailedException;
 
     public MeasurementsConsumer(EventStore<Measurements.SensorEvent> store,
                                 @Value("${measurements.consumer.slowdown:0}") long slowdownMillis,
-                                Optional<BatchErrorHandler> errorHandler) {
+                                @Value("${measurements.consumer.useBatchListenerFailedException:false}") boolean useBatchListenerFailedException) {
         this.eventStore = store;
         this.slowdownMillis = slowdownMillis;
-        this.usingRecoveringBatchErrorHandler = errorHandler.isPresent() && errorHandler.get() instanceof RecoveringErrorHandler;
+        this.useBatchListenerFailedException = useBatchListenerFailedException;
     }
 
     /**
@@ -71,8 +69,8 @@ public class MeasurementsConsumer {
                 NullPointerException businessException = new NullPointerException("Message at "
                         + record.topic() + "-" + record.partition() + ":" + record.offset() + " with key " + record.key() + " was null");
 
-                if (usingRecoveringBatchErrorHandler) {
-                    // Communicate to recovering batch error handler which record in the batch that failed, and the root cause
+                if (useBatchListenerFailedException) {
+                    // Communicate to error handler which record in the batch that failed, and the root cause
                     throw new BatchListenerFailedException(businessException.getMessage(), businessException, record);
                 } else {
                     // Throw raw root cause for other types of error handling
@@ -83,7 +81,8 @@ public class MeasurementsConsumer {
             try {
                 eventStore.storeEvent(record.value());
             } catch (Exception e) {
-                if (usingRecoveringBatchErrorHandler) {
+                if (useBatchListenerFailedException) {
+                    // Communicate to error handler which record in the batch that failed, and the root cause
                     throw new BatchListenerFailedException(e.getMessage(), e, record);
                 } else {
                     throw e;
@@ -103,7 +102,7 @@ public class MeasurementsConsumer {
 
 
     private static Optional<Throwable> failedValueDeserialization(ConsumerRecord<String, Measurements.SensorEvent> record) {
-        Header valueDeserializationError = record.headers().lastHeader(ErrorHandlingDeserializer.VALUE_DESERIALIZER_EXCEPTION_HEADER);
+        Header valueDeserializationError = record.headers().lastHeader(SerializationUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER);
         if (valueDeserializationError != null) {
             try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(valueDeserializationError.value()))){
                 DeserializationException dex = (DeserializationException)ois.readObject();

--- a/clients-spring/src/main/java/no/nav/kafka/sandbox/measurements/MeasurementsRestController.java
+++ b/clients-spring/src/main/java/no/nav/kafka/sandbox/measurements/MeasurementsRestController.java
@@ -8,10 +8,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.LocalDateTime;
-import java.util.Collections;
+import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 public class MeasurementsRestController {
@@ -27,11 +25,12 @@ public class MeasurementsRestController {
      * @return messages from most oldest to most recent, optionally filtering by timestamp.
      */
     @GetMapping(path = "/measurements/api", produces = MediaType.APPLICATION_JSON_VALUE)
-    public List<Measurements.SensorEvent> getMeasurements(@RequestParam(value = "after", required = false, defaultValue = "1970-01-01T00:00")
-                                                          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime after) {
+    public List<Measurements.SensorEvent> getMeasurements(@RequestParam(value = "after", required = false, defaultValue = "1970-01-01T00:00Z")
+                                                          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime after) {
+
         return eventStore.fetchEvents().stream()
                 .filter(e -> e.getTimestamp().isAfter(after))
-                .collect(Collectors.toList());
+                .toList();
     }
 
 }

--- a/clients-spring/src/main/java/no/nav/kafka/sandbox/measurements/errorhandlers/RecoveringErrorHandler.java
+++ b/clients-spring/src/main/java/no/nav/kafka/sandbox/measurements/errorhandlers/RecoveringErrorHandler.java
@@ -2,11 +2,14 @@ package no.nav.kafka.sandbox.measurements.errorhandlers;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.kafka.listener.ListenerExecutionFailedException;
-import org.springframework.kafka.listener.RecoveringBatchErrorHandler;
 import org.springframework.util.backoff.FixedBackOff;
 
-public class RecoveringErrorHandler extends RecoveringBatchErrorHandler {
+/**
+ * This error handler does not recover anything more than exactly failed records
+ */
+public class RecoveringErrorHandler extends DefaultErrorHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger(RecoveringErrorHandler.class);
 

--- a/clients-spring/src/main/resources/application.yml
+++ b/clients-spring/src/main/resources/application.yml
@@ -1,12 +1,12 @@
 spring:
   application:
-    name: Kafka sandbox web
+    name: Kafka sandbox boot-app
   # See class org.springframework.boot.autoconfigure.kafka.KafkaProperties:
   kafka:
     bootstrap-servers: localhost:9092
     consumer:
-      client-id: spring-web
-      group-id: ${GROUPID:spring-web}
+      client-id: boot-app
+      group-id: ${GROUPID:boot-app}
       properties:
         spring.json.trusted.packages: no.nav.kafka.sandbox.messages
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
@@ -44,15 +44,18 @@ measurements:
 
     # Select error handler:
     # 'spring-default': just uses the Spring default for batch error handling (does not explicitly set an error handler).
-    # 'ignore':  logs, but ignores all errors from consumer, implemented in Spring error handler CommonLoggingErrorHandler.
+    # 'log-and-ignore': logs, but ignores all errors from consumer, implemented in Spring error handler CommonLoggingErrorHandler.
     # 'infinite-retry': tries failed batches an infinite number of times, with a backoff/delay between each attempt. Spring DefaultErrorHandler with a BackOff.
-    # 'seek-to-current': Spring SeekToCurrentBatchErrorHandler w/all defaults and no backoff (unlimited retries)
-    # 'seek-to-current-with-backoff': Spring SeekToCurrentBatchErrorHandler w/fixed delay and max 2 retries.
-    # 'retry-with-backoff': Spring RetryingBatchErrorHandler with no configured ConsumerRecordRecoverer
-    # 'retry-with-backoff-recovery': Spring RetryingBatchErrorHandler with custom ConsumerRecordRecoverer set, see RetryingErrorHandler.
-    # 'recovering': Spring RecoveringBatchErrorHandler, see RecoveringErrorHandler.
-    # 'stop-container': Spring ContainerStoppingBatchErrorHandler
+    # 'retry-with-backoff': Spring DefaultErrorHandler with 2 retry attempts
+    # 'retry-with-backoff-recovery': no.nav.k.s.m.e.RetryingErrorHandler with custom ConsumerRecordRecoverer set.
+    # 'recovering': no.nav.k.s.m.e.RecoveringErrorHandler
+    # 'stop-container': Spring CommonContainerStoppingErrorHandler
     error-handler: spring-default
+
+    # Select whether consumer should throw BatchListenerFailedException w/cause when an internal processing failure occurs, or
+    # just directly throw any exception. Setting to true will allow Spring to detect where a failure occured in a batch of multiple
+    # records.
+    useBatchListenerFailedException: false
 
     # Select whether deserialization exceptions of values should be handled:
     handle-deserialization-error: true

--- a/clients-spring/src/main/resources/public/measurements.html
+++ b/clients-spring/src/main/resources/public/measurements.html
@@ -5,13 +5,24 @@
     <meta charset='utf-8'>
     <style>
         body { font-family: Arial, Helvetica, sans-serif; background: black; color: white }
-        .deviceId { color: #ad7fa8 } .value { color: #729fcf } .timestamp { color: #73d216 }
+        .value { color: #729fcf }
+        .timestamp { color: #73d216 }
         h1 { font-style: italic }
         td, tr { padding: 1rem; }
         @keyframes new {
             from {background-color: #999999; }
             to {background-color: #000000;}
         }
+        .color-0 { color: #f8bbd0; }
+        .color-1 { color: #f48fb1; }
+        .color-2 { color: #ffe0b2; }
+        .color-3 { color: #d9ead3; }
+        .color-4 { color: #c6d9f0; }
+        .color-5 { color: #a7d9f0; }
+        .color-6 { color: #d399f0; }
+        .color-7 { color: #f4c2c2; }
+        .color-8 { color: #fce8c3; }
+        .color-9 { color: #f5f5f5; }
         .new { animation-name: new; animation-duration: 1s; }
     </style>
 </head>
@@ -27,6 +38,14 @@
 </table>
 <script>
     const maxRows = 200;
+    function deviceColorClass(deviceId) {
+        let hash = 0;
+        for (let i = 0; i < deviceId.length; i++) {
+            hash = (hash << 5) + deviceId.charCodeAt(i);
+            hash = hash & hash >>> 0;
+        }
+        return 'color-' + Math.abs(hash % 10);
+    }
     function appendToTable(measurements) {
         const tbody = document.getElementById('measurements').cloneNode(true);
         for (var i=0; i<tbody.children.length; i++) {
@@ -38,7 +57,7 @@
             const tr = document.createElement('tr');
             tr.setAttribute('class', 'new');
             let td = document.createElement('td');
-            td.setAttribute('class', 'deviceId');
+            td.setAttribute('class', deviceColorClass(m.deviceId));
             td.appendChild(document.createTextNode(m.deviceId));
             tr.appendChild(td);
 

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -8,11 +8,9 @@
         <groupId>no.nav.kafka</groupId>
         <artifactId>kafka-sandbox</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>clients</artifactId>
-    <packaging>jar</packaging><!-- Executable JAR using Maven shade plugin -->
 
     <dependencies>
         <dependency>
@@ -59,47 +57,46 @@
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
 
     <build>
+        <!-- Create executable JAR with dependencies bundled in a sub-directory. -->
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <id>copy-dependencies</id>
+                        <phase>prepare-package</phase>
                         <goals>
-                            <goal>shade</goal>
+                            <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
-                            <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>no.nav.kafka.sandbox.Bootstrap</mainClass>
-                                </transformer>
-                            </transformers>
-                            <outputFile>${project.build.directory}/${project.build.finalName}-exec.jar</outputFile>
+                            <includeScope>runtime</includeScope>
+                            <outputDirectory>
+                                ${project.build.directory}/libs
+                            </outputDirectory>
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>libs/</classpathPrefix>
+                            <mainClass>no.nav.kafka.sandbox.Bootstrap</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/clients/src/test/java/no/nav/kafka/sandbox/DockerComposeEnvTest.java
+++ b/clients/src/test/java/no/nav/kafka/sandbox/DockerComposeEnvTest.java
@@ -1,25 +1,25 @@
 package no.nav.kafka.sandbox;
 
-import no.nav.kafka.sandbox.DockerComposeEnv.DockerComposeExecutable;
+import no.nav.kafka.sandbox.DockerComposeEnv.DockerComposeCommand;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class DockerComposeEnvTest {
+class DockerComposeEnvTest {
 
     @Test
-    public void testDockerComposeExecutable() {
+    void dockerComposeCommand() {
         assertEquals(List.of("docker-compose", "--no-ansi"),
-                new DockerComposeExecutable("docker-compose", "1.28").executableAndDefaultArgs());
+                new DockerComposeCommand("docker-compose", new String[0], "1.28").executableAndDefaultArgs());
         assertEquals(List.of("docker-compose", "--no-ansi"),
-                new DockerComposeExecutable("docker-compose", "1").executableAndDefaultArgs());
+                new DockerComposeCommand("docker-compose", new String[0], "1").executableAndDefaultArgs());
 
         assertEquals(List.of("docker-compose", "--ansi", "never"),
-                new DockerComposeExecutable("docker-compose", "1.29").executableAndDefaultArgs());
-        assertEquals(List.of("docker-compose", "--ansi", "never"),
-                new DockerComposeExecutable("docker-compose", "2").executableAndDefaultArgs());
+                new DockerComposeCommand("docker-compose", new String[0], "1.29").executableAndDefaultArgs());
+        assertEquals(List.of("docker", "compose", "--ansi", "never"),
+                new DockerComposeCommand("docker", new String[]{"compose"}, "2").executableAndDefaultArgs());
     }
 
 }

--- a/clients/src/test/java/no/nav/kafka/sandbox/KafkaSandboxTest.java
+++ b/clients/src/test/java/no/nav/kafka/sandbox/KafkaSandboxTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Demonstrates use of {@link DockerComposeEnv}, and a few simple tests using a running Kafka instance.
  */
-public class KafkaSandboxTest {
+class KafkaSandboxTest {
 
     private static DockerComposeEnv dockerComposeEnv;
 
@@ -52,9 +52,9 @@ public class KafkaSandboxTest {
     }
 
     @BeforeAll
-    public static void dockerComposeUp() throws Exception {
+    static void dockerComposeUp() throws Exception {
         Assumptions.assumeTrue(DockerComposeEnv.dockerComposeAvailable(),
-                "This test needs a working 'docker-compose' command");
+                "This test needs a working 'docker compose' command");
 
         dockerComposeEnv = DockerComposeEnv.builder("src/test/resources/KafkaDockerComposeEnv.yml")
                 .addAutoPortVariable("KAFKA_PORT")
@@ -66,7 +66,7 @@ public class KafkaSandboxTest {
     }
 
     @AfterAll
-    public static void dockerComposeDown() throws Exception {
+    static void dockerComposeDown() throws Exception {
         if (dockerComposeEnv != null) {
             adminClient.close();
             dockerComposeEnv.down();
@@ -78,17 +78,17 @@ public class KafkaSandboxTest {
     }
 
     @BeforeEach
-    public void createTestTopic() throws Exception {
+    void createTestTopic() throws Exception {
         adminClient.createTopics(Collections.singleton(new NewTopic(testTopic, 1, (short)1))).all().get();
     }
 
     @AfterEach
-    public void deleteTestTopic() throws Exception {
+    void deleteTestTopic() throws Exception {
         adminClient.deleteTopics(Collections.singleton(testTopic)).all().get();
     }
 
     @Test
-    public void waitForMessagesBeforeSending() throws Exception {
+    void waitForMessagesBeforeSending() throws Exception {
         LOG.debug("waitForMessagesBeforeSending start");
         final List<String> messages = List.of("one", "two", "three", "four");
 
@@ -124,7 +124,7 @@ public class KafkaSandboxTest {
     }
 
     @Test
-    public void sendThenReceiveMessages() throws Exception {
+    void sendThenReceiveMessages() throws Exception {
         LOG.debug("sendThenReceiveMessage start");
         final List<String> messages = List.of("one", "two", "three", "four");
 
@@ -157,7 +157,7 @@ public class KafkaSandboxTest {
     }
 
     @Test
-    public void testJsonMessageConsumerAndProducer() throws Exception {
+    void testJsonMessageConsumerAndProducer() throws Exception {
 
         final BlockingQueue<Message> outbox = new ArrayBlockingQueue<>(1);
         final Supplier<Message> supplier = () -> {

--- a/messages/pom.xml
+++ b/messages/pom.xml
@@ -8,20 +8,9 @@
         <artifactId>kafka-sandbox</artifactId>
         <groupId>no.nav.kafka</groupId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>messages</artifactId>
-    <packaging>jar</packaging>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 
     <dependencies>
         <dependency>

--- a/messages/src/main/java/no/nav/kafka/sandbox/messages/Measurements.java
+++ b/messages/src/main/java/no/nav/kafka/sandbox/messages/Measurements.java
@@ -5,12 +5,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.fusesource.jansi.AnsiConsole;
 import org.fusesource.jansi.AnsiRenderer;
 
-import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
 public class Measurements {
@@ -20,14 +19,14 @@ public class Measurements {
         private final String deviceId;
         private final String measureType;
         private final String unitType;
-        private final LocalDateTime timestamp;
+        private final OffsetDateTime timestamp;
         private final Integer value;
 
         @JsonCreator
         public SensorEvent(@JsonProperty("deviceId") String deviceId,
                            @JsonProperty("measureType") String measureType,
                            @JsonProperty("unitType") String unitType,
-                           @JsonProperty("timestamp") LocalDateTime timestamp,
+                           @JsonProperty("timestamp") OffsetDateTime timestamp,
                            @JsonProperty("value") Integer value) {
             this.deviceId = Objects.requireNonNull(deviceId);
             this.measureType = Objects.requireNonNull(measureType);
@@ -48,7 +47,7 @@ public class Measurements {
             return unitType;
         }
 
-        public LocalDateTime getTimestamp() {
+        public OffsetDateTime getTimestamp() {
             return timestamp;
         }
 
@@ -115,12 +114,16 @@ public class Measurements {
     }
 
     /**
-     * @return a single random sensor event
+     * @return a generated sensor event
      */
     public static SensorEvent generateEvent() {
-        final int temp = (int)(Math.random()*20 + 19);
-        return new SensorEvent("sensor-" + ProcessHandle.current().pid(),
-                "temperature", "celcius", LocalDateTime.now(), temp);
+        final long pid = ProcessHandle.current().pid();
+        final int temperatureBase = (int)(pid % 100);
+        final int temperaturVariance = (int)(pid % 10);
+        final String sensorId = "sensor-" + pid;
+
+        final int temp = (int)(Math.random()*temperaturVariance + temperatureBase);
+        return new SensorEvent(sensorId,"temperature", "celcius", OffsetDateTime.now(), temp);
     }
 
     public static void sensorEventToConsole(SensorEvent m) {

--- a/pom.xml
+++ b/pom.xml
@@ -17,74 +17,34 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>11</java.version>
-        <kafka.version>3.0.1</kafka.version>
-        <jackson.version>2.13.2</jackson.version>
-        <junit.version>5.8.2</junit.version>
-        <slf4j.version>1.7.36</slf4j.version>
-        <jansi.version>2.4.0</jansi.version>
+        <java.version>17</java.version>
+
+        <!-- Spring is only used by the `clients-spring` module, but Spring Boot's dependency management
+             is used by the whole project. -->
+        <spring-boot.version>3.2.0</spring-boot.version>
+        <jansi.version>2.4.1</jansi.version>
+
+        <!-- Maven requirements. -->
+        <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
+        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+        <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
+        <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
+        <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.apache.kafka</groupId>
-                <artifactId>kafka-clients</artifactId>
-                <version>${kafka.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-simple</artifactId>
-                <version>${slf4j.version}</version>
-                <scope>runtime</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-jdk8</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-jsr310</artifactId>
-                <version>${jackson.version}</version>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.fusesource.jansi</groupId>
                 <artifactId>jansi</artifactId>
                 <version>${jansi.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-api</artifactId>
-                <version>${junit.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-engine</artifactId>
-                <version>${junit.version}</version>
-                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -95,19 +55,64 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>${maven-compiler-plugin.version}</version>
                     <configuration>
-                        <source>${java.version}</source>
-                        <target>${java.version}</target>
+                        <release>${java.version}</release>
+                        <parameters>true</parameters>
                     </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M5</version>
+                    <version>${maven-surefire-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven-dependency-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>${maven-jar-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>${spring-boot.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>${maven-enforcer-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>enforce-versions</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <requireJavaVersion>
+                                        <version>[${java.version},)</version>
+                                    </requireJavaVersion>
+                                    <requireMavenVersion>
+                                        <version>[3.8,)</version>
+                                    </requireMavenVersion>
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+            </plugin>
+        </plugins>
     </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -18,10 +18,11 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>11</java.version>
-        <kafka.version>3.0.0</kafka.version>
-        <jackson.version>2.13.0</jackson.version>
+        <kafka.version>3.0.1</kafka.version>
+        <jackson.version>2.13.2</jackson.version>
         <junit.version>5.8.2</junit.version>
-        <slf4j.version>1.7.32</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
+        <jansi.version>2.4.0</jansi.version>
     </properties>
 
     <dependencyManagement>
@@ -70,7 +71,7 @@
             <dependency>
                 <groupId>org.fusesource.jansi</groupId>
                 <artifactId>jansi</artifactId>
-                <version>2.4.0</version>
+                <version>${jansi.version}</version>
             </dependency>
 
             <dependency>

--- a/run
+++ b/run
@@ -3,8 +3,8 @@ set -e
 
 cd "$(dirname "$0")"
 
-if ! test -f messages/target/messages-*.jar -a -f clients/target/clients-*-exec.jar; then
+if ! test -f messages/target/messages-*.jar -a -f clients/target/clients-*.jar; then
     mvn -B install
 fi
 
-exec java -jar clients/target/clients-*-exec.jar "$@"
+exec java -jar clients/target/clients-*.jar "$@"


### PR DESCRIPTION
* Update versions and clean up POMs. Spring Boot 3.2 baseline.
* README: Update experiments to reflect current error handlers in Spring Kafka 3.1.
* Fix up the code and add various improvements.
* Fix up `DockerComposeEnv` for Compose V2.